### PR TITLE
Using library get's rid of serialize issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-scripts": "4.0.3",
     "redux": "^4.0.5",
     "redux-saga": "1.1.3",
+    "redux-wait-for-action": "^0.0.8",
     "yup": "0.32.9"
   },
   "scripts": {

--- a/src/store/index.jsx
+++ b/src/store/index.jsx
@@ -1,6 +1,7 @@
-import { createStore, combineReducers, applyMiddleware } from "redux";
+import { createStore, combineReducers, applyMiddleware, compose } from "redux";
 import { Provider } from "react-redux";
 import createSagaMiddleware from "redux-saga";
+import createReduxWaitForMiddleware from 'redux-wait-for-action';
 
 import { formsReducer } from "./form/reducers";
 
@@ -14,7 +15,10 @@ export const AppStore = ({ children }) => {
     combineReducers({
       forms: formsReducer
     }),
-    applyMiddleware(sagaMiddleware)
+    compose(
+      applyMiddleware(sagaMiddleware),
+      applyMiddleware(createReduxWaitForMiddleware())
+    )
   );
   // then run the saga
   sagaMiddleware.run(mySaga);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10337,6 +10337,11 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
+redux-wait-for-action@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/redux-wait-for-action/-/redux-wait-for-action-0.0.8.tgz#980a648db8293119bfaa1375610319f76c20514f"
+  integrity sha1-mApkjbgpMRm/qhN1YQMZ92wgUU8=
+
 redux@^4.0.4, redux@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.1.tgz#76f1c439bb42043f985fbd9bf21990e60bd67f47"


### PR DESCRIPTION
We can leave the teams state concatenating in the reducer, compared to [last PR](https://github.com/guaiamum/redux-saga-formik-promise/pull/2), also no error on tests 😅

Also no need to change the saga's code, we are just listening to the other action's being dispatched from the component!